### PR TITLE
Conformité v2 : ajout de la prise en charge du paramètre qualification-code 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,26 @@ clientFhir.SetEntryLimit(500)
 clientFhir.SetTimeout(30)
 ```
 
+### Searching Practitioner by Qualification Code and Active Status
+
+In v2, the focus has shifted to Practitioner resource with qualification-code parameter for searching by profession/specialty/category.
+
+```go
+bundleRes := clientFhir.
+    Search(fhirInterface.PRACTITIONER).
+    Where(models_r4.Practitioner{}.
+        QualificationCode.
+        Contains().
+        Value("70")).
+    And(models_r4.Practitioner{}.
+        Active.
+        IsActive()).
+    ReturnBundle().Execute()
+```
+
 ### Searching PractitionerRole by Role and Active Status
 
-Please note that we receive a prototype of the BundleResult struct, which is not yet complete, after executing the request.
+Alternatively, you can still search PractitionerRole for activity/situation data:
 
 ```go
 bundleRes := clientFhir.

--- a/cmd/usecases/physioReunionMayotte/main.go
+++ b/cmd/usecases/physioReunionMayotte/main.go
@@ -29,13 +29,14 @@ func main() {
 	clientFhir.SetTimeout(30)
 
 	// Look for all physiotherapists
+	// In v2, use Practitioner resource with qualification-code parameter instead of PractitionerRole with role
 	bundleRes := clientFhir.
-		Search(fhirInterface.PRACTITIONER_ROLE).
-		Where(models_r4.PractitionerRole{}.
-			Role.
+		Search(fhirInterface.PRACTITIONER).
+		Where(models_r4.Practitioner{}.
+			QualificationCode.
 			Contains().
 			Value("70")).
-		And(models_r4.PractitionerRole{}.
+		And(models_r4.Practitioner{}.
 			Active.
 			IsActive()).
 		ReturnBundle().Execute()
@@ -70,7 +71,7 @@ func main() {
 				if postalCode == "" {
 					continue
 				}
-				if postalCode[:3] == "974" || postalCode[:3] == "976" {
+				if len(postalCode) >= 3 && (postalCode[:3] == "974" || postalCode[:3] == "976") {
 					isMayotteOrReunion = true
 					break
 				}
@@ -94,7 +95,7 @@ func main() {
 				Execute()
 
 			log.Print("Practitioner : \n\n", string(practitionerRaw.([]byte)), "\n\n")
-			log.Print("PractitionerRoleRaw : \n\n", string(practitionerRoleRaw.([]byte)), "\n\n")
+			log.Print("PractitionerRole : \n\n", string(practitionerRoleRaw.([]byte)), "\n\n")
 		}
 		if res.GetNextLink() == "" {
 			break

--- a/interface/urlParameters.go
+++ b/interface/urlParameters.go
@@ -7,6 +7,7 @@ type UrlParameters struct {
 	Name       string
 	Address    string
 	Role       string
+	QualificationCode string
 	Active     bool
 	GetPages   string
 	PageId     string
@@ -24,6 +25,9 @@ func (u UrlParameters) BuildUrlValues() url.Values {
 	}
 	if u.Role != "" {
 		values.Add("role", u.Role)
+	}
+	if u.QualificationCode != "" {
+		values.Add("qualification-code", u.QualificationCode)
 	}
 	if u.Active {
 		values.Add("active", "true")
@@ -47,6 +51,9 @@ func (u UrlParameters) Intersection(u_cur UrlParameters) UrlParameters {
 	if u_cur.Active {
 		u.Active = u_cur.Active
 	}
+	if u_cur.QualificationCode != "" {
+		u.QualificationCode = u_cur.QualificationCode
+	}
 	return u
 }
 
@@ -56,6 +63,9 @@ func (u UrlParameters) Union(u_cur UrlParameters) UrlParameters {
 	}
 	if u_cur.Address != "" {
 		u.Address = u.Address + "," + u_cur.Address
+	}
+	if u_cur.QualificationCode != "" {
+		u.QualificationCode = u.QualificationCode + "," + u_cur.QualificationCode
 	}
 	return u
 }
@@ -109,6 +119,24 @@ func (f FhirRole) Contains() struct {
 		Value: func(v string) UrlParameters {
 			return UrlParameters{
 				Role: v,
+			}
+		},
+	}
+}
+
+type FhirQualificationCode struct {
+	Value string
+}
+
+func (f FhirQualificationCode) Contains() struct {
+	Value func(v string) UrlParameters
+} {
+	return struct {
+		Value func(v string) UrlParameters
+	}{
+		Value: func(v string) UrlParameters {
+			return UrlParameters{
+				QualificationCode: v,
 			}
 		},
 	}

--- a/versions/r4/clients/fhir.client.go
+++ b/versions/r4/clients/fhir.client.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	fhirInterface "github.com/Squirrel-Entreprise/go-fhir/interface"
@@ -33,6 +34,10 @@ func NewFhirClient(baseURL, apiKey, apiValue string) fhirInterface.IClient {
 			MaxIdleConns:        0,
 			MaxIdleConnsPerHost: 10,
 		},
+	}
+	// Append /v2 to the base URL for API v2
+	if !strings.HasSuffix(baseURL, "/v2") {
+		baseURL = baseURL + "/v2"
 	}
 	return &fhir{
 		Client:     *clientHttp,

--- a/versions/r4/models/practitioner.model.go
+++ b/versions/r4/models/practitioner.model.go
@@ -8,9 +8,11 @@ import (
 )
 
 type Practitioner struct {
-	Client  fhirInterface.IClient
-	Address fhirInterface.FhirAddress
-	Name    fhirInterface.FhirName
+	Client            fhirInterface.IClient
+	Address           fhirInterface.FhirAddress
+	Name              fhirInterface.FhirName
+	QualificationCode fhirInterface.FhirQualificationCode
+	Active            fhirInterface.FhirActive
 }
 
 func (p *Practitioner) ById(id string) fhirInterface.IParameters {
@@ -25,7 +27,7 @@ func (p *Practitioner) ById(id string) fhirInterface.IParameters {
 func (p *Practitioner) Where(option fhirInterface.UrlParameters) fhirInterface.IParameters {
 	fmt.Printf("\t\t--> Where()\n")
 
-	return &parameters_r4.OrganizationParameters{
+	return &parameters_r4.PractitionerParameters{
 		Client:     p.Client,
 		Uri:        "/Practitioner",
 		Parameters: option,


### PR DESCRIPTION
Prise en charge du paramètre de recherche qualification-code lors des requêtes sur les ressources Practitioner, conformément à la documentation de l’API FHIR v2.

Désormais, il faut utiliser l’endpoint Practitioner (et non plus PractitionerRole) pour retrouver des praticiens en fonction de leurs qualifications.

Les changements apportés :
- Ajout du champ QualificationCode dans la struct UrlParameters.
- Mise à jour du générateur d’URL pour inclure le paramètre qualification-code.
- Ajout d’un helper FhirQualificationCode pour faciliter la construction fluide des requêtes.
